### PR TITLE
Rewrite local $ref pointers when resolving a remote pointer

### DIFF
--- a/Eask
+++ b/Eask
@@ -1,8 +1,8 @@
 (package "jsonp"
-         "1.1.1"
+         "1.1.2"
          "Resolve JSON pointers in ELisp objects")
 
-(website-url "https://github.com/joshbax189/jsonp")
+(website-url "https://github.com/joshbax189/jsonp-el")
 (keywords "comm" "tools")
 
 (package-file "jsonp.el")

--- a/jsonp.el
+++ b/jsonp.el
@@ -2,7 +2,7 @@
 
 ;; Author: Josh Bax
 ;; Maintainer: Josh Bax
-;; Version: 1.1.1
+;; Version: 1.1.2
 ;; Package-Requires: ((emacs "28.1"))
 ;; Homepage: https://github.com/joshbax189/jsonp-el
 ;; Keywords: comm, tools

--- a/jsonp.el
+++ b/jsonp.el
@@ -152,10 +152,10 @@ yields
          (path-result nil))
     (when (cdr (url-path-and-query base-parsed))
       (signal 'jsonp-remote-error
-              (format "Cannot merge URIs with query %s" base-uri)))
+              (format "Cannot merge URIs that include a query string %s" base-uri)))
     (when (cdr (url-path-and-query uri-parsed))
       (signal 'jsonp-remote-error
-              (format "Cannot merge URIs with query %s" uri)))
+              (format "Cannot merge URIs that include a query string %s" uri)))
     ;; merge dot paths
     (while path-segments
       (let ((next (car path-segments)))

--- a/test/jsonp-test.el
+++ b/test/jsonp-test.el
@@ -546,6 +546,15 @@ server: istio-envoy
             "https://example.com/something")
            "https://example.com/foo/bar#baz")))
 
+(ert-deftest jsonp-expand-relative-uri/test-absolute ()
+  "Absolute URLs should not be expanded."
+  (should (equal (jsonp-expand-relative-uri "http://other.net/baz" "http://example.com/foo/bar")
+                 "http://other.net/baz")))
+
+(ert-deftest jsonp-expand-relative-uri/test-non-http ()
+  "Absolute URLs should not be expanded."
+  (should-error (jsonp-expand-relative-uri "ftp://other.net/baz" "http://example.com/foo/bar")))
+
 ;;;; jsonp--array-p
 (ert-deftest jsonp-array-p/test-vectors ()
   "Tests whether vectors satisfy the checks."


### PR DESCRIPTION
This is so that other local pointers can still be resolved in the incoming JSON.

For example, replacing refs in the following
```json
/* https://example.com/a.json */
{
  "x": {
    "$ref": "https://example.com/b.json#/y"
  }
}
```
where we have
```json
/* https://example.com/b.json */
{
  "y": { "$ref": "#/z" },
  "z": "target"
}
```

Without rewriting local refs
```json
{
  "x": {
    "$ref": "#/z"
  }
}
```
The next step of resolving is impossible, since the definition for `z` is missing.
Instead, with rewriting, we get
```json
{
  "x": {
    "$ref": "https://example.com/b.json#/z"
  }
}
```
And so `z` can be looked up in the cache.