### PR TITLE
Fix RFC6901 URL

### DIFF
--- a/jsonp.el
+++ b/jsonp.el
@@ -27,7 +27,7 @@
 ;;; Commentary:
 
 ;; This library provides functions to resolve JSON pointers, as defined in
-;; RFC6901 (https://datatracker.ietf.org/doc/html/rfc6901p),
+;; RFC6901 (https://datatracker.ietf.org/doc/html/rfc6901),
 ;; within parsed JSON objects, also supporting remote resolution (fetching
 ;; JSON from a URI).
 


### PR DESCRIPTION
The URL was pointing wrong. Probably from a typo after a `C-p` or so. :)